### PR TITLE
Fix small issues in the addition of `hir::LookAround`

### DIFF
--- a/regex-automata/src/meta/reverse_inner.rs
+++ b/regex-automata/src/meta/reverse_inner.rs
@@ -170,7 +170,7 @@ fn top_concat(mut hir: &Hir) -> Option<Vec<Hir>> {
             | HirKind::Literal(_)
             | HirKind::Class(_)
             | HirKind::Look(_)
-            | HirKind::Lookaround(_)
+            | HirKind::LookAround(_)
             | HirKind::Repetition(_)
             | HirKind::Alternation(_) => return None,
             HirKind::Capture(hir::Capture { ref sub, .. }) => sub,
@@ -207,7 +207,7 @@ fn flatten(hir: &Hir) -> Hir {
         HirKind::Literal(hir::Literal(ref x)) => Hir::literal(x.clone()),
         HirKind::Class(ref x) => Hir::class(x.clone()),
         HirKind::Look(ref x) => Hir::look(x.clone()),
-        HirKind::Lookaround(ref x) => {
+        HirKind::LookAround(ref x) => {
             Hir::lookaround(x.with(flatten(x.sub())))
         }
         HirKind::Repetition(ref x) => Hir::repetition(x.with(flatten(&x.sub))),

--- a/regex-automata/src/meta/reverse_inner.rs
+++ b/regex-automata/src/meta/reverse_inner.rs
@@ -207,7 +207,9 @@ fn flatten(hir: &Hir) -> Hir {
         HirKind::Literal(hir::Literal(ref x)) => Hir::literal(x.clone()),
         HirKind::Class(ref x) => Hir::class(x.clone()),
         HirKind::Look(ref x) => Hir::look(x.clone()),
-        HirKind::Lookaround(ref x) => Hir::lookaround(x.clone()),
+        HirKind::Lookaround(ref x) => {
+            Hir::lookaround(x.with(flatten(x.sub())))
+        }
         HirKind::Repetition(ref x) => Hir::repetition(x.with(flatten(&x.sub))),
         // This is the interesting case. We just drop the group information
         // entirely and use the child HIR itself.

--- a/regex-automata/src/nfa/thompson/compiler.rs
+++ b/regex-automata/src/nfa/thompson/compiler.rs
@@ -1003,7 +1003,7 @@ impl Compiler {
             Class(Class::Bytes(ref c)) => self.c_byte_class(c),
             Class(Class::Unicode(ref c)) => self.c_unicode_class(c),
             Look(ref look) => self.c_look(look),
-            Lookaround(_) => todo!("implement lookaround NFA compilation"),
+            LookAround(_) => todo!("implement lookaround NFA compilation"),
             Repetition(ref rep) => self.c_repetition(rep),
             Capture(ref c) => self.c_cap(c.index, c.name.as_deref(), &c.sub),
             Concat(ref es) => self.c_concat(es.iter().map(|e| self.c(e))),

--- a/regex-syntax/src/hir/literal.rs
+++ b/regex-syntax/src/hir/literal.rs
@@ -2456,6 +2456,22 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "Missing parser support for lookaround"]
+    fn lookaround() {
+        assert_eq!(exact(["ab"]), e(r"a(?<=qwe)b"));
+        assert_eq!(exact(["ab"]), e(r"a(?<!qwe)b"));
+
+        assert_eq!(exact(["ab"]), e(r"(?<=qwe)ab"));
+        assert_eq!(exact(["ab"]), e(r"(?<!qwe)ab"));
+
+        assert_eq!(exact(["ab"]), e(r"ab(?<=qwe)"));
+        assert_eq!(exact(["ab"]), e(r"ab(?<!qwe)"));
+
+        let expected = (seq([I("aZ"), E("ab")]), seq([I("Zb"), E("ab")]));
+        assert_eq!(expected, e(r"(?<=foo)aZ*b"));
+    }
+
+    #[test]
     fn repetition() {
         assert_eq!(exact(["a", ""]), e(r"a?"));
         assert_eq!(exact(["", "a"]), e(r"a??"));

--- a/regex-syntax/src/hir/literal.rs
+++ b/regex-syntax/src/hir/literal.rs
@@ -172,7 +172,7 @@ impl Extractor {
         use crate::hir::HirKind::*;
 
         match *hir.kind() {
-            Empty | Look(_) | Lookaround(_) => {
+            Empty | Look(_) | LookAround(_) => {
                 Seq::singleton(self::Literal::exact(vec![]))
             }
             Literal(hir::Literal(ref bytes)) => {

--- a/regex-syntax/src/hir/literal.rs
+++ b/regex-syntax/src/hir/literal.rs
@@ -2458,13 +2458,13 @@ mod tests {
     #[test]
     #[ignore = "Missing parser support for lookaround"]
     fn lookaround() {
-        assert_eq!(exact(["ab"]), e(r"a(?<=qwe)b"));
+        assert_eq!(exact(["ab"]), e(r"a(?<=qwa)b"));
         assert_eq!(exact(["ab"]), e(r"a(?<!qwe)b"));
 
         assert_eq!(exact(["ab"]), e(r"(?<=qwe)ab"));
         assert_eq!(exact(["ab"]), e(r"(?<!qwe)ab"));
 
-        assert_eq!(exact(["ab"]), e(r"ab(?<=qwe)"));
+        assert_eq!(exact(["ab"]), e(r"ab(?<=qab)"));
         assert_eq!(exact(["ab"]), e(r"ab(?<!qwe)"));
 
         let expected = (seq([I("aZ"), E("ab")]), seq([I("Zb"), E("ab")]));

--- a/regex-syntax/src/hir/mod.rs
+++ b/regex-syntax/src/hir/mod.rs
@@ -1976,6 +1976,9 @@ impl Drop for Hir {
             | HirKind::Class(_)
             | HirKind::Look(_) => return,
             HirKind::Capture(ref x) if x.sub.kind.subs().is_empty() => return,
+            HirKind::Lookaround(ref x) if x.sub().kind.subs().is_empty() => {
+                return
+            }
             HirKind::Repetition(ref x) if x.sub.kind.subs().is_empty() => {
                 return
             }

--- a/regex-syntax/src/hir/mod.rs
+++ b/regex-syntax/src/hir/mod.rs
@@ -2569,8 +2569,6 @@ impl Properties {
             maximum_len: Some(0),
             literal: false,
             alternation_literal: false,
-            explicit_captures_len: sub_p.explicit_captures_len(),
-            static_explicit_captures_len: sub_p.static_explicit_captures_len(),
             ..*sub_p.0.clone()
         };
         Properties(Box::new(inner))

--- a/regex-syntax/src/hir/mod.rs
+++ b/regex-syntax/src/hir/mod.rs
@@ -735,7 +735,7 @@ pub enum HirKind {
     Class(Class),
     /// A look-around assertion. A look-around match always has zero length.
     Look(Look),
-    /// A look-around subexpression
+    /// A look-around subexpression.
     LookAround(LookAround),
     /// A repetition operation applied to a sub-expression.
     Repetition(Repetition),
@@ -2561,6 +2561,7 @@ impl Properties {
         Properties(Box::new(inner))
     }
 
+    /// Create a new set of HIR properties for a look-around.
     fn lookaround(lookaround: &LookAround) -> Properties {
         let sub_p = lookaround.sub().properties();
         let inner = PropertiesI {
@@ -2568,6 +2569,8 @@ impl Properties {
             maximum_len: Some(0),
             literal: false,
             alternation_literal: false,
+            explicit_captures_len: sub_p.explicit_captures_len(),
+            static_explicit_captures_len: sub_p.static_explicit_captures_len(),
             ..*sub_p.0.clone()
         };
         Properties(Box::new(inner))

--- a/regex-syntax/src/hir/mod.rs
+++ b/regex-syntax/src/hir/mod.rs
@@ -1796,15 +1796,15 @@ impl Look {
     }
 }
 
-/// Represents a general lookaround assertion
+/// Represents a general lookaround assertion.
 ///
 /// Currently, only lookbehind assertions are supported.
 /// Furthermore, capture groups inside assertions are not supported.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Lookaround {
-    /// A positive lookbehind assertion
+    /// A positive lookbehind assertion.
     PositiveLookBehind(Box<Hir>),
-    /// A negative lookbehind assertion
+    /// A negative lookbehind assertion.
     NegativeLookBehind(Box<Hir>),
 }
 
@@ -1813,16 +1813,31 @@ impl Lookaround {
     /// lookaround assertion to hold.
     pub fn sub(&self) -> &Hir {
         match self {
-            Lookaround::PositiveLookBehind(sub)
-            | Lookaround::NegativeLookBehind(sub) => sub,
+            Self::PositiveLookBehind(sub) | Self::NegativeLookBehind(sub) => {
+                sub
+            }
         }
     }
 
     /// Returns a mutable reference to the inner expression
     pub fn sub_mut(&mut self) -> &mut Hir {
         match self {
-            Lookaround::PositiveLookBehind(sub)
-            | Lookaround::NegativeLookBehind(sub) => sub,
+            Self::PositiveLookBehind(sub) | Self::NegativeLookBehind(sub) => {
+                sub
+            }
+        }
+    }
+
+    /// Returns a new lookaround of the same kind, but with its
+    /// sub-expression replaced with the one given.
+    pub fn with(&self, sub: Hir) -> Lookaround {
+        match self {
+            Self::PositiveLookBehind(_) => {
+                Self::PositiveLookBehind(Box::new(sub))
+            }
+            Self::NegativeLookBehind(_) => {
+                Self::NegativeLookBehind(Box::new(sub))
+            }
         }
     }
 }

--- a/regex-syntax/src/hir/print.rs
+++ b/regex-syntax/src/hir/print.rs
@@ -228,10 +228,10 @@ impl<W: fmt::Write> Visitor for Writer<W> {
                 }
             },
             HirKind::Lookaround(hir::Lookaround::PositiveLookBehind(_)) => {
-                self.wtr.write_str(r"(?<=)")?;
+                self.wtr.write_str(r"(?<=")?;
             }
             HirKind::Lookaround(hir::Lookaround::NegativeLookBehind(_)) => {
-                self.wtr.write_str(r"(?<!)")?;
+                self.wtr.write_str(r"(?<!")?;
             }
             HirKind::Capture(hir::Capture { ref name, .. }) => {
                 self.wtr.write_str("(")?;
@@ -482,6 +482,18 @@ mod tests {
         roundtrip("(?:a)", "a");
 
         roundtrip("((((a))))", "((((a))))");
+    }
+
+    #[test]
+    #[ignore = "Missing parser support for lookaround"]
+    fn print_look_around() {
+        roundtrip("(?<=)", "(?<=(?:))");
+        roundtrip("(?<!)", "(?<!(?:))");
+
+        roundtrip("(?<=a)", "(?<=a)");
+        roundtrip("(?<!a)", "(?<!a)");
+
+        roundtrip("(?<=(?<!(?<!(?<=a))))", "(?<=(?<!(?<!(?<=a))))");
     }
 
     #[test]

--- a/regex-syntax/src/hir/print.rs
+++ b/regex-syntax/src/hir/print.rs
@@ -227,10 +227,10 @@ impl<W: fmt::Write> Visitor for Writer<W> {
                     self.wtr.write_str(r"\b{end-half}")?;
                 }
             },
-            HirKind::Lookaround(hir::Lookaround::PositiveLookBehind(_)) => {
+            HirKind::LookAround(hir::LookAround::PositiveLookBehind(_)) => {
                 self.wtr.write_str(r"(?<=")?;
             }
-            HirKind::Lookaround(hir::Lookaround::NegativeLookBehind(_)) => {
+            HirKind::LookAround(hir::LookAround::NegativeLookBehind(_)) => {
                 self.wtr.write_str(r"(?<!")?;
             }
             HirKind::Capture(hir::Capture { ref name, .. }) => {
@@ -300,7 +300,7 @@ impl<W: fmt::Write> Visitor for Writer<W> {
             HirKind::Capture(_)
             | HirKind::Concat(_)
             | HirKind::Alternation(_)
-            | HirKind::Lookaround(_) => {
+            | HirKind::LookAround(_) => {
                 self.wtr.write_str(r")")?;
             }
         }

--- a/regex-syntax/src/hir/visitor.rs
+++ b/regex-syntax/src/hir/visitor.rs
@@ -83,6 +83,9 @@ enum Frame<'a> {
     /// A stack frame allocated just before descending into a capture's child
     /// node.
     Capture(&'a hir::Capture),
+    /// A stack frame allocated just before descending into a look-around's
+    /// child node.
+    LookAround(&'a hir::Lookaround),
     /// The stack frame used while visiting every child node of a concatenation
     /// of expressions.
     Concat {
@@ -162,6 +165,7 @@ impl<'a> HeapVisitor<'a> {
         match *hir.kind() {
             HirKind::Repetition(ref x) => Some(Frame::Repetition(x)),
             HirKind::Capture(ref x) => Some(Frame::Capture(x)),
+            HirKind::Lookaround(ref x) => Some(Frame::LookAround(x)),
             HirKind::Concat(ref x) if x.is_empty() => None,
             HirKind::Concat(ref x) => {
                 Some(Frame::Concat { head: &x[0], tail: &x[1..] })
@@ -180,6 +184,7 @@ impl<'a> HeapVisitor<'a> {
         match induct {
             Frame::Repetition(_) => None,
             Frame::Capture(_) => None,
+            Frame::LookAround(_) => None,
             Frame::Concat { tail, .. } => {
                 if tail.is_empty() {
                     None
@@ -208,6 +213,7 @@ impl<'a> Frame<'a> {
         match *self {
             Frame::Repetition(rep) => &rep.sub,
             Frame::Capture(capture) => &capture.sub,
+            Frame::LookAround(lookaround) => &lookaround.sub(),
             Frame::Concat { head, .. } => head,
             Frame::Alternation { head, .. } => head,
         }

--- a/regex-syntax/src/hir/visitor.rs
+++ b/regex-syntax/src/hir/visitor.rs
@@ -213,7 +213,7 @@ impl<'a> Frame<'a> {
         match *self {
             Frame::Repetition(rep) => &rep.sub,
             Frame::Capture(capture) => &capture.sub,
-            Frame::LookAround(lookaround) => &lookaround.sub(),
+            Frame::LookAround(lookaround) => lookaround.sub(),
             Frame::Concat { head, .. } => head,
             Frame::Alternation { head, .. } => head,
         }

--- a/regex-syntax/src/hir/visitor.rs
+++ b/regex-syntax/src/hir/visitor.rs
@@ -85,7 +85,7 @@ enum Frame<'a> {
     Capture(&'a hir::Capture),
     /// A stack frame allocated just before descending into a look-around's
     /// child node.
-    LookAround(&'a hir::Lookaround),
+    LookAround(&'a hir::LookAround),
     /// The stack frame used while visiting every child node of a concatenation
     /// of expressions.
     Concat {
@@ -165,7 +165,7 @@ impl<'a> HeapVisitor<'a> {
         match *hir.kind() {
             HirKind::Repetition(ref x) => Some(Frame::Repetition(x)),
             HirKind::Capture(ref x) => Some(Frame::Capture(x)),
-            HirKind::Lookaround(ref x) => Some(Frame::LookAround(x)),
+            HirKind::LookAround(ref x) => Some(Frame::LookAround(x)),
             HirKind::Concat(ref x) if x.is_empty() => None,
             HirKind::Concat(ref x) => {
                 Some(Frame::Concat { head: &x[0], tail: &x[1..] })


### PR DESCRIPTION
The rename commit makes the diff less visible. I split each change in a separate commit with an explanation of the change.

It is probably better to review the changes by looking at the diff from individual commits.