### PR TITLE
Add unit tests for look-behind assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex"
-version = "1.11.1"  #:version
+version = "1.12.0"  #:version
 authors = ["The Rust Project Developers", "Andrew Gallant <jamslam@gmail.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -176,14 +176,14 @@ default-features = false
 # For the actual regex engines.
 [dependencies.regex-automata]
 path = "regex-automata"
-version = "0.4.8"
+version = "0.5.0"
 default-features = false
 features = ["alloc", "syntax", "meta", "nfa-pikevm"]
 
 # For parsing regular expressions.
 [dependencies.regex-syntax]
 path = "regex-syntax"
-version = "0.8.5"
+version = "0.9.0"
 default-features = false
 
 [dev-dependencies]

--- a/regex-automata/Cargo.toml
+++ b/regex-automata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex-automata"
-version = "0.4.9"  #:version
+version = "0.5.0"  #:version
 authors = ["The Rust Project Developers", "Andrew Gallant <jamslam@gmail.com>"]
 description = "Automata construction and matching using regular expressions."
 documentation = "https://docs.rs/regex-automata"
@@ -86,7 +86,7 @@ internal-instrument-pikevm = ["logging", "std"]
 aho-corasick = { version = "1.0.0", optional = true, default-features = false }
 log = { version = "0.4.14", optional = true }
 memchr = { version = "2.6.0", optional = true, default-features = false }
-regex-syntax = { path = "../regex-syntax", version = "0.8.5", optional = true, default-features = false }
+regex-syntax = { path = "../regex-syntax", version = "0.9.0", optional = true, default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.69"

--- a/regex-automata/src/dfa/dense.rs
+++ b/regex-automata/src/dfa/dense.rs
@@ -5083,6 +5083,12 @@ impl BuildError {
         BuildError { kind: BuildErrorKind::Unsupported(msg) }
     }
 
+    pub(crate) fn unsupported_lookaround() -> BuildError {
+        let msg = "cannot build DFAs for regexes with look-around\
+                   sub-expressions; use a different regex engine";
+        BuildError { kind: BuildErrorKind::Unsupported(msg) }
+    }
+
     pub(crate) fn too_many_states() -> BuildError {
         BuildError { kind: BuildErrorKind::TooManyStates }
     }

--- a/regex-automata/src/dfa/determinize.rs
+++ b/regex-automata/src/dfa/determinize.rs
@@ -219,6 +219,10 @@ impl<'a> Runner<'a> {
             return Err(BuildError::unsupported_dfa_word_boundary_unicode());
         }
 
+        if self.nfa.lookaround_count() > 0 {
+            return Err(BuildError::unsupported_lookaround());
+        }
+
         // A sequence of "representative" bytes drawn from each equivalence
         // class. These representative bytes are fed to the NFA to compute
         // state transitions. This allows us to avoid re-computing state

--- a/regex-automata/src/hybrid/dfa.rs
+++ b/regex-automata/src/hybrid/dfa.rs
@@ -4056,6 +4056,9 @@ impl Builder {
         &self,
         nfa: thompson::NFA,
     ) -> Result<DFA, BuildError> {
+        if nfa.lookaround_count() > 0 {
+            return Err(BuildError::unsupported_lookaround());
+        }
         let quitset = self.config.quit_set_from_nfa(&nfa)?;
         let classes = self.config.byte_classes_from_nfa(&nfa, &quitset);
         // Check that we can fit at least a few states into our cache,

--- a/regex-automata/src/hybrid/error.rs
+++ b/regex-automata/src/hybrid/error.rs
@@ -61,6 +61,12 @@ impl BuildError {
                    different regex engine";
         BuildError { kind: BuildErrorKind::Unsupported(msg) }
     }
+
+    pub(crate) fn unsupported_lookaround() -> BuildError {
+        let msg = "cannot build DFAs for regexes with look-around\
+                   sub-expressions; use a different regex engine";
+        BuildError { kind: BuildErrorKind::Unsupported(msg) }
+    }
 }
 
 #[cfg(feature = "std")]

--- a/regex-automata/src/meta/wrappers.rs
+++ b/regex-automata/src/meta/wrappers.rs
@@ -204,6 +204,8 @@ impl BoundedBacktrackerEngine {
         {
             if !info.config().get_backtrack()
                 || info.config().get_match_kind() != MatchKind::LeftmostFirst
+                // TODO: remove once look-around support is added.
+                || nfa.lookaround_count() > 0
             {
                 return Ok(None);
             }

--- a/regex-automata/src/nfa/thompson/compiler.rs
+++ b/regex-automata/src/nfa/thompson/compiler.rs
@@ -1045,7 +1045,7 @@ impl Compiler {
         &self,
         lookaround: &LookAround,
     ) -> Result<ThompsonRef, BuildError> {
-        let sub = self.c(lookaround.sub());
+        let sub = self.c(lookaround.sub())?;
         let pos = match lookaround {
             LookAround::NegativeLookBehind(_) => false,
             LookAround::PositiveLookBehind(_) => true,

--- a/regex-automata/src/nfa/thompson/nfa.rs
+++ b/regex-automata/src/nfa/thompson/nfa.rs
@@ -1102,7 +1102,7 @@ impl NFA {
 
     /// Returns how many look-around sub-expressions this nfa contains
     #[inline]
-    pub fn lookaround_count(&self) -> SmallIndex {
+    pub fn lookaround_count(&self) -> usize {
         self.0.lookaround_count
     }
 
@@ -1269,7 +1269,7 @@ pub(super) struct Inner {
     /// How many look-around expression this NFA contains.
     /// This is needed to initialize the table for storing the result of
     /// look-around evaluation
-    lookaround_count: SmallIndex,
+    lookaround_count: usize,
     /// Heap memory used indirectly by NFA states and other things (like the
     /// various capturing group representations above). Since each state
     /// might use a different amount of heap, we need to keep track of this
@@ -1387,7 +1387,8 @@ impl Inner {
             }
             State::CheckLookAround { lookaround_idx: look_idx, .. }
             | State::WriteLookAround { lookaround_idx: look_idx } => {
-                self.lookaround_count = self.lookaround_count.max(look_idx);
+                self.lookaround_count =
+                    self.lookaround_count.max(look_idx.as_usize() + 1);
             }
             State::Union { .. }
             | State::BinaryUnion { .. }

--- a/regex-automata/src/nfa/thompson/pikevm.rs
+++ b/regex-automata/src/nfa/thompson/pikevm.rs
@@ -1216,7 +1216,7 @@ impl PikeVM {
 }
 
 impl PikeVM {
-    fn lookaround_count(&self) -> SmallIndex {
+    fn lookaround_count(&self) -> usize {
         self.nfa.lookaround_count()
     }
 
@@ -1992,7 +1992,7 @@ impl Cache {
             stack: vec![],
             curr: ActiveStates::new(re),
             next: ActiveStates::new(re),
-            lookaround: vec![None; re.lookaround_count().as_usize()],
+            lookaround: vec![None; re.lookaround_count()],
         }
     }
 

--- a/regex-automata/tests/dfa/onepass/suite.rs
+++ b/regex-automata/tests/dfa/onepass/suite.rs
@@ -79,7 +79,10 @@ fn compiler(
                 // Since our error types are all generally opaque, we just
                 // look for an error string. Not great, but not the end of the
                 // world.
-                if test.compiles() && msg.contains("not one-pass") {
+                if test.compiles()
+                    && (msg.contains("not one-pass")
+                        || msg.contains("look-around"))
+                {
                     return Ok(CompiledRegex::skip());
                 }
                 return Err(err.into());

--- a/regex-automata/tests/dfa/suite.rs
+++ b/regex-automata/tests/dfa/suite.rs
@@ -292,7 +292,17 @@ fn compiler(
         if !configure_regex_builder(test, &mut builder) {
             return Ok(CompiledRegex::skip());
         }
-        create_matcher(&builder, pre, builder.build_many(&regexes)?)
+        let re = match builder.build_many(regexes) {
+            Ok(re) => re,
+            Err(err)
+                if test.compiles()
+                    && format!("{err}").contains("look-around") =>
+            {
+                return Ok(CompiledRegex::skip());
+            }
+            Err(err) => return Err(err.into()),
+        };
+        create_matcher(&builder, pre, re)
     }
 }
 

--- a/regex-automata/tests/lib.rs
+++ b/regex-automata/tests/lib.rs
@@ -65,6 +65,7 @@ fn suite() -> anyhow::Result<regex_test::RegexTests> {
     load!("fowler/basic");
     load!("fowler/nullsubexpr");
     load!("fowler/repetition");
+    load!("lookaround");
 
     Ok(tests)
 }

--- a/regex-automata/tests/nfa/thompson/backtrack/suite.rs
+++ b/regex-automata/tests/nfa/thompson/backtrack/suite.rs
@@ -74,6 +74,10 @@ fn min_visited_capacity() -> Result<()> {
                 .configure(config_thompson(test))
                 .syntax(config_syntax(test))
                 .build_many(&regexes)?;
+            // TODO: remove once look-around is supported.
+            if nfa.lookaround_count() > 0 {
+                return Ok(CompiledRegex::skip());
+            }
             let mut builder = BoundedBacktracker::builder();
             if !configure_backtrack_builder(test, &mut builder) {
                 return Ok(CompiledRegex::skip());
@@ -105,6 +109,10 @@ fn compiler(
             return Ok(CompiledRegex::skip());
         }
         let re = builder.build_many(&regexes)?;
+        // TODO: remove once look-around is supported.
+        if re.get_nfa().lookaround_count() > 0 {
+            return Ok(CompiledRegex::skip());
+        }
         let mut cache = re.create_cache();
         Ok(CompiledRegex::compiled(move |test| -> TestResult {
             run_test(&re, &mut cache, test)

--- a/regex-cli/Cargo.toml
+++ b/regex-cli/Cargo.toml
@@ -29,8 +29,8 @@ lexopt = "0.3.0"
 log = { version = "0.4.17", features = ["std"] }
 memmap2 = "0.9.4"
 regex = { version = "1.9.0", path = ".." }
-regex-automata = { version = "0.4.8", path = "../regex-automata", features = ["logging"] }
+regex-automata = { version = "0.5.0", path = "../regex-automata", features = ["logging"] }
 regex-lite = { version = "0.1.0", path = "../regex-lite" }
-regex-syntax = { version = "0.8.5", path = "../regex-syntax" }
+regex-syntax = { version = "0.9.0", path = "../regex-syntax" }
 tabwriter = { version = "1.2.1", features = ["ansi_formatting"] }
 textwrap = { version = "0.16.0", default-features = false }

--- a/regex-syntax/Cargo.toml
+++ b/regex-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex-syntax"
-version = "0.8.5"  #:version
+version = "0.9.0"  #:version
 authors = ["The Rust Project Developers", "Andrew Gallant <jamslam@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/regex/tree/master/regex-syntax"

--- a/regex-syntax/src/hir/literal.rs
+++ b/regex-syntax/src/hir/literal.rs
@@ -172,9 +172,8 @@ impl Extractor {
         use crate::hir::HirKind::*;
 
         match *hir.kind() {
-            Empty | Look(_) | LookAround(_) => {
-                Seq::singleton(self::Literal::exact(vec![]))
-            }
+            Empty | Look(_) => Seq::singleton(self::Literal::exact(vec![])),
+            LookAround(_) => Seq::infinite(),
             Literal(hir::Literal(ref bytes)) => {
                 let mut seq =
                     Seq::singleton(self::Literal::exact(bytes.to_vec()));

--- a/testdata/lookaround.toml
+++ b/testdata/lookaround.toml
@@ -1,0 +1,59 @@
+[[test]]
+name = "basic lookbehind positive"
+regex = "(?<=b)a"
+haystack = "ba"
+matches = [[1, 2]]
+
+[[test]]
+name = "basic lookbehind negative"
+regex = "(?<!c)a"
+haystack = "ba"
+matches = [[1, 2]]
+
+[[test]]
+name = "basic lookbehind positive no match"
+regex = "(?<=c)a"
+haystack = "ba"
+matches = []
+
+[[test]]
+name = "basic lookbehind negative no match"
+regex = "(?<!b)a"
+haystack = "ba"
+matches = []
+
+[[test]]
+name = "lookbehind in quantifier non-repeating"
+regex = "(?:(?<=c)a)+"
+haystack = "badacacaea"
+matches = [[5,6], [7,8]]
+
+[[test]]
+name = "lookbehind in quantifier repeating"
+regex = "(?:(?<=a)a)+"
+haystack = "babaabaaabaaaac"
+matches = [[4,5], [7,9], [11,14]]
+
+[[test]]
+name = "lookbehind with quantifier"
+regex = "(?<=cb+)a"
+haystack = "acabacbacbbaea"
+matches = [[7,8], [11,12]]
+
+[[test]]
+name = "nested lookbehind"
+regex = "(?<=c[def]+(?<!fed))a"
+haystack = "cdaceacfeeacfedeacfeda"
+matches = [[2,3], [5,6], [10,11], [16,17]]
+
+[[test]]
+name = "lookbehind with alternation"
+regex = "(?<=def|abc)a"
+haystack = "defaabcadefbca"
+matches = [[3,4], [7,8]]
+
+[[test]]
+name = "lookbehind in alternation"
+regex = "(?<=c+)a|(?<=d+)a"
+haystack = "aabacadaccaddaea"
+matches = [[5,6], [7,8], [10,11], [13,14]]


### PR DESCRIPTION
Filtering on the tests for engines that don't support look-behinds is a bit hacky (based on printed error message from `BuildError` of the respective engine), but this is congruent with the way employed in the codebase for some other filter condition on the `onepass` engine.

I disabled pre-filters by changing look-around states to return an infinite sequence instead of an empty literal.
I also changed the total look-around count field in the NFA struct to be usize again, since this makes more sense as it can be one more than the max index and there is only one copy of it as opposed to the multiple places for the actual look-around indices.